### PR TITLE
Add database handling for repositories and manifests

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,17 @@
+create table repositories (
+	name       text    not null,
+	created_at integer not null default current_timestamp,
+	primary key (name)
+);
+
+create table manifests (
+	repository text    not null,
+	digest     text    not null,
+	tag        text,
+	created_at integer not null default current_timestamp,
+	updated_at integer not null default current_timestamp,
+	primary key (repository, digest),
+	foreign key (repository) references repositories (name)
+);
+create index manifests_repository_tag_idx on manifests (repository, tag);
+create unique index manifests_repository_tag_key on manifests (repository, tag);

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ router.all('*',
 /**
  * @typedef Env
  * @property {import('@cloudflare/workers-types').R2Bucket} BUCKET
+ * @property {import('@cloudflare/workers-types').D1Database} DB
  * @property {string} AUTH_USER
  * @property {string} AUTH_PASSWORD
  */

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -11,3 +11,7 @@ custom_domain = true
 [[r2_buckets]]
 binding = "BUCKET"
 bucket_name = "registry"
+
+[[d1_databases]]
+binding = "DB"
+database_id = "e1233b26-0da3-4c43-a60d-09d6f7c7ee0c"


### PR DESCRIPTION
This commit includes the creation of repositories and manifests tables in the database schema in `schema.sql` file. Furthermore, it modifies the `registry.js` file to handle data insertions, updates, and deletions in these tables. The `index.js` file has been updated to import the database, and configuration has been added to `wrangler.toml` to specify the database binding and ID.